### PR TITLE
Added exception when file not found in manifest

### DIFF
--- a/app/mix.php
+++ b/app/mix.php
@@ -2,7 +2,7 @@
 
 // mix('css/app.css')
 // mix('js/app.js')
-function mix($path, $json = false, $shouldHotReload = false)
+function mix($originalPath, $json = false, $shouldHotReload = false)
 {
     if (! $json) static $json;
     if (! $shouldHotReload) static $shouldHotReload;
@@ -23,11 +23,18 @@ function mix($path, $json = false, $shouldHotReload = false)
 
     $path = collect($json['assetsByChunkName'])
         ->flatten()
-        ->first(function ($compiledFile) use ($path, $json) {
+        ->first(function ($compiledFile) use ($originalPath, $json) {
             $compiledFile = trim(str_replace($json['hash'].'.', '', $compiledFile), '/');
 
-            return $compiledFile === trim($path, '/');
+            return $compiledFile === trim($originalPath, '/');
         });
+
+	if(!$path){
+		throw new Exception(
+			'The file "' . $originalPath . '" could not be located in the Laravel Mix Manifest file. ' .
+			'Please run "npm run webpack" and try again.'
+		);
+	}
 
     return $shouldHotReload ? "http://localhost:8080{$path}" : url($path);
 }


### PR DESCRIPTION
When the mix() function cannot find a file, it throws an exception notifying the user of the issue.